### PR TITLE
Implement finished_at_start and finished_at_end filters

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_filters.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_filters.rb
@@ -9,10 +9,16 @@ module MissionControl::Jobs::JobFilters
 
   private
     def set_filters
-      @job_filters = { job_class_name: params.dig(:filter, :job_class_name).presence, queue_name: params.dig(:filter, :queue_name).presence }.compact
+      @job_filters = { job_class_name: params.dig(:filter, :job_class_name).presence, queue_name: params.dig(:filter, :queue_name).presence,
+                       finished_at_start: date_with_time_zone(params.dig(:filter, :finished_at_start).presence), finished_at_end: date_with_time_zone(params.dig(:filter, :finished_at_end).presence) }.compact
     end
 
     def active_filters?
       @job_filters.any?
+    end
+
+    def date_with_time_zone(date)
+      return date if date.nil?
+      DateTime.parse(date).in_time_zone
     end
 end

--- a/app/views/mission_control/jobs/jobs/_filters.html.erb
+++ b/app/views/mission_control/jobs/jobs/_filters.html.erb
@@ -12,6 +12,16 @@
           <%= form.text_field :queue_name, value: @job_filters[:queue_name], class: "input", list: "queue-names", placeholder: "Filter by queue name..." %>
         </div>
 
+        <% if jobs_status == 'finished' %>
+          <div class="select is-rounded">
+            <%= form.datetime_field :finished_at_start, value: @job_filters[:finished_at_start], class: "input", placeholder: "Finished from" %>
+          </div>
+
+          <div class="select is-rounded">
+            <%= form.datetime_field :finished_at_end, value: @job_filters[:finished_at_end], class: "input", placeholder: "Finished to" %>
+          </div>
+        <% end %>
+
         <%= hidden_field_tag :server_id, MissionControl::Jobs::Current.server.id %>
 
         <datalist id="job-classes" class="is-hidden">
@@ -29,7 +39,7 @@
     </div>
 
     <div class="control">
-      <%= link_to "Clear", application_jobs_path(MissionControl::Jobs::Current.application, jobs_status, job_class_name: nil, queue_name: nil), class: "button" %>
+      <%= link_to "Clear", application_jobs_path(MissionControl::Jobs::Current.application, jobs_status, job_class_name: nil, queue_name: nil, finished_at_start: nil, finished_at_end: nil), class: "button" %>
     </div>
   </div>
 </div>

--- a/lib/active_job/jobs_relation.rb
+++ b/lib/active_job/jobs_relation.rb
@@ -23,9 +23,9 @@ class ActiveJob::JobsRelation
   include Enumerable
 
   STATUSES = %i[ pending failed in_progress blocked scheduled finished ]
-  FILTERS = %i[ queue_name job_class_name ]
+  FILTERS = %i[ queue_name job_class_name finished_at_start finished_at_end ]
 
-  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id ]
+  PROPERTIES = %i[ queue_name status offset_value limit_value job_class_name worker_id recurring_task_id finished_at_start finished_at_end ]
   attr_reader *PROPERTIES, :default_page_size
 
   delegate :last, :[], :reverse, to: :to_a
@@ -51,12 +51,16 @@ class ActiveJob::JobsRelation
   # * <tt>:queue_name</tt> - To only include the jobs in the provided queue.
   # * <tt>:worker_id</tt> - To only include the jobs processed by the provided worker.
   # * <tt>:recurring_task_id</tt> - To only include the jobs corresponding to runs of a recurring task.
-  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil)
+  # * <tt>:finished_at_start</tt> - To only include the jobs finished after the provided date.
+  # * <tt>:finished_at_end</tt> - To only include the jobs finished before the provided date.
+  def where(job_class_name: nil, queue_name: nil, worker_id: nil, recurring_task_id: nil, finished_at_start: nil, finished_at_end: nil)
     # Remove nil arguments to avoid overriding parameters when concatenating +where+ clauses
     arguments = { job_class_name: job_class_name,
       queue_name: queue_name,
       worker_id: worker_id,
-      recurring_task_id: recurring_task_id
+      recurring_task_id: recurring_task_id,
+      finished_at_start: finished_at_start,
+      finished_at_end: finished_at_end
     }.compact.collect { |key, value| [ key, value.to_s ] }.to_h
 
     clone_with **arguments


### PR DESCRIPTION
jobs_relation finished_at_start and finished_at_end filters

natively_supported finished_at_* filters for solid_queue

added filters to _filters partial and params

added timezone

show finished_at filters if jobs_status is 'finished'

added comments to jobs_relation where method

clean finished_at_* filter values when clear button clicked

double instead of single quoted strings (rubocop)

enhacements set filters